### PR TITLE
Separate "major" and "course"

### DIFF
--- a/example.typ
+++ b/example.typ
@@ -9,6 +9,7 @@
     name: "Max Mustermann",
     matriculation-number: "1208964",
     major: "TIX20",
+    course: "TIX20",
   ),
   company: (
     name: "Example Corporation",

--- a/template.typ
+++ b/template.typ
@@ -82,7 +82,7 @@
         row-gutter: 0.75em,
         column-gutter: 2cm,
         [Bearbeitungszeitraum], handling-period,
-        [Matrikelnummer, Kurs], [#author.matriculation-number, #author.major],
+        [Matrikelnummer, Kurs], [#author.matriculation-number, #author.course],
         [Ausbildungsfirma], [#company.name, #company.city],
         [Betreuer der Ausbildungsfirma], company.supervisor,
         [Gutachter der Dualen Hochschule], dhbw.reviewer,


### PR DESCRIPTION
According to the official template, the "major" should be something like "Maschinenbau" while the "course" would be "TIX20" for example.

Note: I'm opening a sparate PR for each atomic change, so that you can merge the changes you want and close the ones you dont 😄 